### PR TITLE
Add table scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A CLI application for watching fabric throughput, congestion, and errors.
 
+Use the Up and Down arrow keys to scroll through the node table when the list exceeds the available screen space.
+
 ![image](https://github.com/user-attachments/assets/26ff51a4-d8c0-4b49-828d-b686f80fda39)
 
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,6 +55,9 @@ pub struct App {
     pub sort_column: i32,
     pub sort_ascending: bool,
 
+    /// Current scroll offset for the nodes table
+    pub table_offset: usize,
+
     /// Manages all event handling (tick, crossterm, discovery, counters).
     pub events: EventHandler,
 }
@@ -109,6 +112,7 @@ impl App {
             auto_update_counter: 0,
             sort_column: -1,
             sort_ascending: false,
+            table_offset: 0,
             events: EventHandler::new(app_config),
         };
 
@@ -248,6 +252,25 @@ impl App {
                 ..
             } => {
                 self.sort_ascending = !self.sort_ascending;
+            }
+
+            // Scroll table down
+            KeyEvent {
+                code: KeyCode::Down,
+                ..
+            } => {
+                if !self.nodes.is_empty() {
+                    let max_offset = self.nodes.len().saturating_sub(1);
+                    self.table_offset = (self.table_offset + 1).min(max_offset);
+                }
+            }
+
+            // Scroll table up
+            KeyEvent {
+                code: KeyCode::Up,
+                ..
+            } => {
+                self.table_offset = self.table_offset.saturating_sub(1);
             }
 
             _ => {}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -288,18 +288,25 @@ impl App {
                 .add_modifier(Modifier::BOLD),
         );
 
-        let rows = node_info.iter().map(|(lid, desc, ports, r_bw, x_bw, waits, errs, err_str)| {
-            Row::new(vec![
-                Cell::from(format!("{}", lid)),
-                Cell::from(truncate_fit(desc, widths[1])),
-                Cell::from(format!("{}", ports)),
-                Cell::from(format!("{:.2}", r_bw)),
-                Cell::from(format!("{:.2}", x_bw)),
-                Cell::from(format!("{:.2}", waits)),
-                Cell::from(format!("{}", errs)),
-                Cell::from(truncate_fit(err_str, widths[7])),
-            ])
-        });
+        let visible_rows = area.height.saturating_sub(1) as usize;
+        let offset = self.table_offset.min(node_info.len().saturating_sub(visible_rows));
+
+        let rows = node_info
+            .iter()
+            .skip(offset)
+            .take(visible_rows)
+            .map(|(lid, desc, ports, r_bw, x_bw, waits, errs, err_str)| {
+                Row::new(vec![
+                    Cell::from(format!("{}", lid)),
+                    Cell::from(truncate_fit(desc, widths[1])),
+                    Cell::from(format!("{}", ports)),
+                    Cell::from(format!("{:.2}", r_bw)),
+                    Cell::from(format!("{:.2}", x_bw)),
+                    Cell::from(format!("{:.2}", waits)),
+                    Cell::from(format!("{}", errs)),
+                    Cell::from(truncate_fit(err_str, widths[7])),
+                ])
+            });
 
         let constraints = [
             Constraint::Length(widths[0] as u16),


### PR DESCRIPTION
## Summary
- let user scroll the nodes table using up/down keys
- document arrow key scrolling support

## Testing
- `cargo fmt -- --check` *(fails: rustfmt component missing)*
- `cargo check` *(fails: failed to load source for dependency `rsmad`)*